### PR TITLE
Unused

### DIFF
--- a/asfpy/ldapadmin.py
+++ b/asfpy/ldapadmin.py
@@ -25,7 +25,6 @@ assert sys.version_info >= (3, 2)
 
 import ldap
 import ldap.modlist
-import ldif
 import re
 import crypt
 import random


### PR DESCRIPTION
When the file was renamed, some code was dropped so ldif is no longer needed