### PR TITLE
Update python versions in workflows

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8]
+        python-version: [3.13]
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -12,7 +12,12 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8]
+        python-version:
+          - 3.9
+          - 3.10
+          - 3.11
+          - 3.12
+          - 3.13
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -13,11 +13,11 @@ jobs:
       max-parallel: 4
       matrix:
         python-version:
-          - 3.9
-          - 3.10
-          - 3.11
-          - 3.12
-          - 3.13
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
+          - '3.13'
 
     steps:
     - uses: actions/checkout@master

--- a/pylintrc
+++ b/pylintrc
@@ -53,7 +53,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.10
+py-version=3.9
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.


### PR DESCRIPTION
This PR changes the following things:

- run tests with a wider range of python versions: 3.9 - 3.13
- run pylint with 3.13 and use 3.9 as minimum supported version as defined in the pyproject.toml file