### PR TITLE
bump cryptography to 44.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<4"
+python = ">=3.9.2,<4"
 aiohttp = "^3.10.5"
 bonsai = "^1.5.3"
 ezt = "^1.1"
@@ -18,7 +18,7 @@ python-ldap = "^3.4.4"
 requests = "^2.32.3"
 easydict = "^1.13"
 pyyaml = "^6.0.2"
-cryptography = "^43.0.1"
+cryptography = "^44.0.2"
 cffi = "^1.17.1"
 watchfiles = "^1.0.0"
 


### PR DESCRIPTION
As the latest version of cryptography does not support python 3.9.0 and 3.9.1, also the python version needed to be adjusted.

See https://github.com/pyca/cryptography/blob/main/pyproject.toml#L50