### PR TITLE
Add Makefile to simplify publishing, update README with latest publishing instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,29 @@ build:
 	@echo "Building module"
 	@echo "==============="
 
-	poetry build
+	@poetry build
 
 check:
 	@echo "Checking for a dirty workspace"
 	@echo "=============================="
 
-	git status -s -uno | grep '.' && echo "Workspace contains uncommitted changes" && exit 1
-	git status -s -unormal | grep -E "asfpy|tests" | grep "?" && echo "Workspace contains untracked source files" && exit 1
+	@git status -s -uno | grep '.' && echo "Workspace contains uncommitted changes, aborting publishing" && exit 1
+	@git status -s -unormal | grep -E "asfpy|tests" | grep "?" && echo "Workspace contains untracked source files, aborting publishing" && exit 1
 
 publish: check build
-	poetry publish
+	$(eval VERSION=$(shell poetry version -s))
+
+	@poetry publish && echo "\nPublished version $(VERSION) to pypi.org, do not forget to tag the repo with v$(VERSION)."
 
 publish-test: build
-	poetry publish -r testpypi
+	$(eval REPO=$(shell poetry config repositories.testpypi | grep -o 'test.pypi.org'))
+	@if [ "$(REPO)" != "test.pypi.org" ]; then \
+		echo "\nSetting up testpypi repository"; \
+		poetry config repositories.testpypi https://test.pypi.org/legacy/; \
+		echo "Dont forget to configure your token for test.pypi.org using:"; \
+		echo "  poetry config pypi-token.testpypi <your-token>\n"; \
+	fi
+
+	$(eval VERSION=$(shell poetry version -s))
+
+	@poetry publish -r testpypi && echo "\nPublished version $(VERSION) to test.pypi.org."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: build check publish publish-test
+
+PYTHON ?= $(which python3)
+SCRIPTS ?= scripts/poetry
+
+build:
+	@echo "Building module"
+	@echo "==============="
+
+	poetry build
+
+check:
+	@echo "Checking for a dirty workspace"
+	@echo "=============================="
+
+	git status -s -uno | grep '.' && echo "Workspace contains uncommitted changes" && exit 1
+	git status -s -unormal | grep -E "asfpy|tests" | grep "?" && echo "Workspace contains untracked source files" && exit 1
+
+publish: check build
+	poetry publish
+
+publish-test: build
+	poetry publish -r testpypi

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: build check publish publish-test
 
+SHELL := /bin/bash
+
 PYTHON ?= $(which python3)
 SCRIPTS ?= scripts/poetry
 
@@ -18,6 +20,13 @@ check:
 
 publish: check build
 	$(eval VERSION=$(shell poetry version -s))
+
+	@echo "Releasing version ${VERSION}"
+
+	@if [[ "$(VERSION)" =~ "dev" ]]; then \
+		echo "Detected development version, abort publishing"; \
+		exit 1; \
+	fi
 
 	@poetry publish && echo "\nPublished version $(VERSION) to pypi.org, do not forget to tag the repo with v$(VERSION)."
 

--- a/README.md
+++ b/README.md
@@ -19,32 +19,62 @@ Preparation
 Bump the version number in `setup.py` and run:
 `python3 -m build`
 
+## Installation
+
+Create and activate a virtual environment and then install `asfpy` using [pip](https://pip.pypa.io):
+
+```console
+$ pip install "asfpy"
+```
+
+Note: Adding `[ldap]` or `[aioldap]` extras will install optional dependencies for LDAP support that will 
+require additional [system dependencies](https://github.com/noirello/bonsai?tab=readme-ov-file#requirements-for-building):
+
+```console
+$ pip install "asfpy[aioldap]"
+```
 
 ## Publishing a new asfpy package
 
-After building the asfpy package, run the following command, where $version is the new version to publish:
+Create an account on https://pypi.org/, then add a token with an "all projects" scope.
 
-`python3 -m twine upload dist/asfpy-$version*`  (for instance `dist/asfpy-0.38*`)
+Configure your credentials for the `pypi` repository:
 
-The above command will upload the `.whl` and the `.tar.gz` (the glob-asterisk is important!)
+```console
+$ poetry config pypi-token.pypi <your-token>
+```
+
+Finally publish to `pypi.org`:
+
+```console
+$ make publish
+```
 
 See [this guide](https://realpython.com/pypi-publish-python-package/#publish-your-package-to-pypi) for more details on working with PyPi.
 
 Please also create a tag for the release.
 
-### for testing
+### Publishing to test.pypi.org
 
 Create an account on https://test.pypi.org/, then add a token with an
-"all projects" scope. Place that into your `.pypirc` like so:
+"all projects" scope.
 
-```
-[testpypi]
-  repository = https://test.pypi.org/legacy/
-  username = __token__
-  password = pypi-tokenstringgoeshere
+Add a `testpypi` repository to your poetry config:
+
+```console
+$ poetry config repositories.testpypi https://test.pypi.org/legacy/
 ```
 
-Then you can test an upload with:
-`python3 -m twine upload -r testpypi dist/asf-py$version*`
+Configure your credentials for the `testpypi` repository:
+
+```console
+$ poetry config pypi-token.testpypi <your-token>
+```
+
+Finally publish to `test.pypi.org`:
+
+```console
+$ make publish-test
+```
 
 The package should upload to the test.pypi.org service.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,21 @@ This Python library contains features commonly used at the Apache Software Found
 
 ## Building asfpy package
 
-Preparation
+Prerequisites:
 
-* `apt install python3.10-venv`
-* `pip3 install build twine`
+- `poetry`: install e.g. with pipx `pipx install poetry`
 
-Bump the version number in `setup.py` and run:
-`python3 -m build`
+Building the package:
+
+```console
+$ poetry build
+```
+
+Running the tests:
+
+```console
+$ poetry run pytest
+```
 
 ## Installation
 


### PR DESCRIPTION
The `Makefile` has basically 2 targets:

- publish
- publish-test

to publish to `pypi.org` and `test.pypi.org`.

There are some basic checks if the workspace is dirty when trying to publish to pypi.

What is missing is that a tag is also created when releasing.