### PR TITLE
Replace crypt library with Passlib

### DIFF
--- a/asfpy/ldapadmin.py
+++ b/asfpy/ldapadmin.py
@@ -26,8 +26,7 @@ assert sys.version_info >= (3, 2)
 import ldap
 import ldap.modlist
 import re
-# Due to be removed; suppress warnings to ensure other problems are more obvious
-import crypt # pylint: disable=deprecated-module,import-error
+import passlib
 import random
 import string
 
@@ -364,7 +363,7 @@ class manager:
         password = ''.join(random.choice(string.ascii_letters + string.digits) for i in range(16))
         if forcePass:
             password = forcePass
-        password_crypted = crypt.crypt(password, crypt.mksalt(method=crypt.METHOD_MD5))
+        password_crypted = passlib.hash.md5_crypt.hash(password)
 
         ldiff = {
             'objectClass': ['person', 'top', 'posixAccount', 'organizationalPerson', 'inetOrgPerson', 'asf-committer', 'hostObject', 'ldapPublicKey'],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ pyyaml = "^6.0.2"
 cryptography = "^44.0.2"
 cffi = "^1.17.1"
 watchfiles = "^1.0.0"
+passlib = { version = "^1.7.4", optional = true }
 
 [build-system]
 requires = ["poetry-core"]
@@ -31,8 +32,8 @@ pytest = "*"
 pylint = "*"
 
 [tool.poetry.extras]
-ldap = ["python-ldap"]
-aioldap = ["bonsai"]
+ldap = ["python-ldap", "passlib"]
+aioldap = ["bonsai", "passlib"]
 
 [tool.pytest.ini_options]
 testpaths  = ["test"]


### PR DESCRIPTION
The stdlib crypt library has been deprecated and is removed in the 3.13 release of Python. This PR subs in the passlib library, which is one of the recommended replacements.