### PR TITLE
Update the cryptography package dependency due to CVE-2026-26007

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ python-ldap = { version = "^3.4.4", optional = true }
 requests = "^2.32.3"
 easydict = "^1.13"
 pyyaml = "^6.0.2"
-cryptography = "^44.0.2"
+cryptography = "^46.0.5"
 cffi = "^1.17.1"
 watchfiles = "^1.0.0"
 passlib = { version = "^1.7.4", optional = true }


### PR DESCRIPTION
Resolves [Security #2](https://github.com/apache/infrastructure-asfpy/security/dependabot/2), and removes a blocker for https://github.com/apache/tooling-trusted-releases/security/dependabot/12.

I ran tests on this branch, and they passed:

```
~/infrastructure-asfpy # poetry build
Creating virtualenv asfpy-68ndzt2b-py3.12 in /root/.cache/pypoetry/virtualenvs
Building asfpy (0.57)
Building sdist
  - Building sdist
  - Built asfpy-0.57.tar.gz
Building wheel
  - Building wheel
  - Built asfpy-0.57-py3-none-any.whl
~/infrastructure-asfpy # PYTHONPATH=. poetry run pytest
================================================================= test session starts =================================================================
platform linux -- Python 3.12.12, pytest-8.4.2, pluggy-1.6.0
rootdir: /root/infrastructure-asfpy
configfile: pyproject.toml
testpaths: test
collected 6 items

test/test_crypto.py ..                                                                                                                          [ 33%]
test/test_messaging.py .                                                                                                                        [ 50%]
test/test_stopwatch.py ...                                                                                                                      [100%]

================================================================== 6 passed in 2.16s ==================================================================
```
