### PR TITLE
Lower the required Python to align with tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.59"
 description = "ASF Common Python Methods"
 authors = [{name = "ASF Infrastructure", email = "users@infra.apache.org"}]
 readme = "README.md"
-requires-python = ">=3.9.2"
+requires-python = ">=3.8.20"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
I set the requirement too high for tests, which support 3.8 still. This fixes that.